### PR TITLE
CSV Cost Code Import 

### DIFF
--- a/csv_imports/README
+++ b/csv_imports/README
@@ -1,0 +1,13 @@
+Takes in a CSV string and it parses out the headers and
+the row. Each row is supposed to correspond to a
+`CostCode`. Cost Codes are in a tree structure, each one
+_can_ have a parent. Each one has a code, usually a two
+digit number. 
+
+Codes are identified by their `full_code`, for example a
+CostCode with `code = 01` and a parent with code `01`
+has a `full_code` of `01-01`. 
+
+*New Feature Request*
+Client wants to be able to upload a CSV with 3 tiers (currently only accepts /
+works with 2)

--- a/csv_imports/lib/cost_code_import.rb
+++ b/csv_imports/lib/cost_code_import.rb
@@ -1,0 +1,55 @@
+require "csv"
+
+class CostCodeImport
+  def self.import(csv, provider)
+    roots = []
+    errors = []
+
+    CSV.parse(csv, headers: true) do |row|
+      major = row["Division"].strip    if row["Division"]
+      minor = row["Cost Code"].strip   if row["Cost Code"]
+      name  = row["Description"].strip if row["Description"]
+
+
+      next if [major, minor, name].all?{|f| f.blank?}
+
+      new_hash = {
+        code: major,
+        name: name,
+        biller_type: provider.class.to_s,
+        biller_id: provider.id
+      }
+
+      if minor.blank?
+        new_root = ::CostCode.new(new_hash)
+        unless new_root.save
+          errors << [
+            "Couldn't create CostCode #{new_hash.inspect}, #{new_root.errors.full_messages}",
+            new_root
+          ]
+          break
+        end
+
+        roots << new_root
+        next
+      end
+
+      root = roots.find{|ccs| ccs.code.to_s == major}
+      unless root
+        errors << ["Couldn't find root for #{row.inspect}", row]
+        break
+      end
+
+      # Set up hash for new leaf cost code
+      new_hash[:code] = minor
+
+      new_cc = ::CostCode.new(new_hash)
+      new_cc.parent = root
+      unless new_cc.save
+        errors << ["Couldn't create new CostCode: #{new_hash.inspect} because #{new_cc.errors.full_messages}", new_cc]
+      end
+    end
+
+    errors
+  end
+end

--- a/csv_imports/test/cost_code_test.rb
+++ b/csv_imports/test/cost_code_test.rb
@@ -1,0 +1,82 @@
+require "minitest/autorun"
+require "active_record"
+require_relative "../lib/cost_code_import"
+
+class CostCodeTest < Minitest::Test
+  def setup
+    setup_database!
+  end
+
+  def test_csv_import
+    csv = "Division,Cost Code,Description\n01,,Name\n01,01,Name\n"
+    project = Project.create
+
+    current_count = CostCode.count
+    CostCodeImport.import(csv, project)
+
+    assert_equal CostCode.count, current_count + 2
+  end
+
+  def test_csv_import_leaf_with_no_root_will_not_create
+    csv = "Division,Cost Code,Description\n01,,Root\n02,01,Leaf no Root\n"
+    project = Project.create
+
+    current_count = CostCode.count
+    errors = CostCodeImport.import(csv, project)
+
+    assert_equal CostCode.count, current_count + 1
+    assert_match /Couldn't find root/, errors.first[0]
+  end
+
+  def test_csv_import_with_no_description_creates_none
+    csv = "Division,Cost Code,Description\n01,,\n"
+    project = Project.create
+
+    current_count = CostCode.count
+    errors = CostCodeImport.import(csv, project)
+
+    assert_equal CostCode.count, current_count + 0
+    assert_match /Couldn't create CostCode/, errors.first[0]
+  end
+end
+
+
+# Models
+###
+class CostCode < ActiveRecord::Base
+  validates :code, presence: true
+  validates :name, presence: true
+
+  belongs_to :parent, class_name: CostCode
+  belongs_to :biller, polymorphic: true
+
+  def codes
+    if parent
+      parent.codes << code
+    else
+      [code]
+    end
+  end
+
+  def full_code
+    codes.join("-")
+  end
+end
+
+class Project < ActiveRecord::Base
+  has_many :cost_codes, as: :biller
+end
+
+# Test Helper Methods
+###
+def setup_database!
+  ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+
+  {
+    "cost_codes": "code STRING, name STRING, biller_type STRING, biller_id INTEGER, parent_id INTEGER",
+    "projects": "name STRING"
+  }.each do |table_name, columns_as_sql_string|
+    ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
+  end
+end
+


### PR DESCRIPTION
Jist of the code -
Takes in a CSV string and it parses out the headers and the row. Each row is supposed to correspond to a `CostCode`. Cost Codes are in a tree structure, each one _can_ have a parent. Each one has a code, usually a two digit number. 

Codes are identified by their `full_code`, for example a CostCode with `code = 01` and a parent with code `01` has a `full_code` of `01-01`. 

_New Feature Request_
Client wants to be able to upload a CSV with 3 tiers (currently only accepts / works with 2)
